### PR TITLE
ISSUE 118 - The [Required] clinician search param can be left blank

### DIFF
--- a/src/pages/Search/Search.js
+++ b/src/pages/Search/Search.js
@@ -144,8 +144,12 @@ export default class Search extends Component {
       }
   }
   handleChange1 = (name) => {
-    this.setState({name: name})
-    console.log(`Option selected:`, name)
+      if (name.length === 0){
+          this.setState({name: null});
+      } else {
+          this.setState({name: name});
+      }
+      console.log(`Option selected name:`, name)
   }
 
   handleChange2 = (service) => {


### PR DESCRIPTION
- Added if condition to catch if name array is null then set the name state to null
- Since issue was caused by when you enter in a name for the clinician search param. Then click enter. Then click back and delete the name. Then click enter. This causes the name array to be empty and not null type. Therefore it bypassed the "basic error checking" comment of !name.
https://app.zenhub.com/workspaces/kidsability-5c3faa0d4ee8c91d66b72672/issues/uwblueprint/kidsability/118
