### PR TITLE
Firefox fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,7 +78,11 @@ export default class App extends Component {
      *    }
      */
     getScheduleAPI = async (firstName, lastName) => {
-        const response = await fetch(proxy+'/api/schedules/'+firstName+"/"+lastName);
+        const response = await fetch(proxy+'/api/schedules/'+firstName+"/"+lastName, {
+            headers : {
+                'Cache-Control': 'no-cache'
+            }
+        });
         const body = await response.json();
         if (response.status !== 200) {
             throw Error(body.message);

--- a/src/pages/View/CalendarView/CalendarView.js
+++ b/src/pages/View/CalendarView/CalendarView.js
@@ -24,8 +24,8 @@ export default class CalendarView extends Component {
                 let elem = week[j];
                 Events.push({
                     title: elem.Names,
-                    start: moment(elem.Date).hour(elem.Start.split(":")[0]).minute(elem.Start.split(":")[1]).toDate(),
-                    end: moment(elem.Date).hour(elem.End.split(":")[0]).minute(elem.End.split(":")[1]).toDate(),
+                    start: moment(elem.Date, 'DD-MMM-YY').hour(elem.Start.split(":")[0]).minute(elem.Start.split(":")[1]).toDate(),
+                    end: moment(elem.Date, 'DD-MMM-YY').hour(elem.End.split(":")[0]).minute(elem.End.split(":")[1]).toDate(),
                     "allDay?": false,
                     "resource?": "Hello"
                 })

--- a/src/pages/View/ChartView/ChartView.js
+++ b/src/pages/View/ChartView/ChartView.js
@@ -81,7 +81,7 @@ export default class ChartView extends Component {
                                 this.props.data[key].map((elem, index) =>
                                     <tr key={index}>
                                         <td>
-                                            {moment(elem.Date).format('MMM D')}
+                                            {moment(elem.Date, 'DD-MMM-YY').format('MMM D')}
                                         </td>
                                         <td className="wide">{moment(elem.Start, 'h:mm').format('h:mm a')} - {moment(elem.End, 'h:mm').format('h:mm a')}</td>
                                         <td>{elem.Location.charAt(0) + elem.Location.substr(1).toLowerCase()}</td>


### PR DESCRIPTION
1st Issue:
In our api request code, we check the response code equals `200 success`.
On chrome, the request `getScheduleAPI` always returns `200 success`. On firefox, the request can return a response `304 content not changed` and fetch the json object from cache. Since schedules can change often and schedules data isn't huge, I've added
```
headers : {
  'Cache-Control': 'no-cache'
}
```
So Firefox will request a new copy each time and not look in the cache. Additionally, the response will be 200 each time.

2nd Issue:
Moment js relies on internal date implementations which differ among browsers. See https://momentjs.com/docs/#/parsing/string/. The format `'DD-MMM-YY'` should be provided for all Moment objects. See https://momentjs.com/docs/#/parsing/string-format/.