### PR TITLE
Fixed saving times

### DIFF
--- a/src/pages/View/ChartView/ChartView.js
+++ b/src/pages/View/ChartView/ChartView.js
@@ -12,10 +12,6 @@ export default class ChartView extends Component {
             note: "",
             param: {}
         };
-
-        this.close = this.close.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleChange = this.handleChange.bind(this);
     }
 
     onClickSave = (e, param) => {
@@ -25,12 +21,11 @@ export default class ChartView extends Component {
         }
     }
     
-    handleSubmit(e) {
+    handleSubmit = (e) => {
         e.preventDefault();
-        var param = this.state.param;
-        var note = (this.state.note === "") ? "No note has been added for this time." : this.state.note;
-        console.log(note);
-        var save_obj = {
+        const param = this.state.param;
+        const note = (this.state.note === "") ? "No note has been added for this time." : this.state.note;
+        const save_obj = {
             Name: param.Names,
             Date: param. Date,
             Start: param.Start,
@@ -47,7 +42,7 @@ export default class ChartView extends Component {
         })
     }
 
-    handleChange(e) {
+    handleChange = (e) => {
         this.setState({note: e.target.value})
     }
 
@@ -56,76 +51,66 @@ export default class ChartView extends Component {
     }
 
     render() {
-        const {open} = this.state;
-        
         return (
             <div>
             <div className="table">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th className="wide">Time</th>
-                        <th>Location</th>
-                        <th>Availability</th>
-                        <th>Save</th>
-                    </tr>
-                </thead>
-                <div className="table-content">
-                    { Object.keys(this.props.data).map((key, index) => (
-                        <tbody key={key}>
-                            <tr>
-                                <td className="section-header">{key === 0 ? 'This week' : `In ${key} week${key === 1 ? '' : 's'}`}</td>
-                            </tr>
-                            {
-                                this.props.data[key].map((elem, index) =>
-                                    <tr key={index}>
-                                        <td>
-                                            {moment(elem.Date, 'DD-MMM-YY').format('MMM D')}
-                                        </td>
-                                        <td className="wide">{moment(elem.Start, 'h:mm').format('h:mm a')} - {moment(elem.End, 'h:mm').format('h:mm a')}</td>
-                                        <td>{elem.Location.charAt(0) + elem.Location.substr(1).toLowerCase()}</td>
-                                        <td>
-                                            <div className="dots">
-                                                {elem.Names.map((e, i) =>
-                                                    <div className="dot" style={{ backgroundColor: this.props.clinicians[e].color }} key={i}></div>)}
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <Icon className="save-button" style={{color: "purple"}} onClick={(e) => this.onClickSave(e, elem)}>
-                                                bookmark_border
-                                            </Icon>
-                                            <Modal
-                                                open = {open}
-                                                onClose={this.close}
-                                                center
-                                                classNames={{modal: "customModal", overlay: "customOverlay"}} 
-                                            >
-                                                <form onSubmit={this.handleSubmit}>
-                                                    <label>
-                                                        Clinician Notes:
-                                                    </label>
-                                                    <div>
-                                                        <textarea name="notes" value={this.state.note} 
-                                                            onChange={this.handleChange} className="notebox" rows="4" 
-                                                        />
-                                                    </div>
-                                                    <div className="save-button-container">
-                                                        <button type="submit" value="Submit" className="save-note">Save Time</button>
-                                                    </div>
-                                                </form>
-                                            </Modal>
-                                        </td>
-                                    </tr>
-                                )
-                            }
-                        </tbody>
-                    )) }
-                </div>
-            </table>
-        </div>
-        </div>
-
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th className="wide">Time</th>
+                            <th>Location</th>
+                            <th>Availability</th>
+                            <th>Save</th>
+                        </tr>
+                    </thead>
+                    <div className="table-content">
+                        { Object.keys(this.props.data).map((key, index) => (
+                            <tbody key={key}>
+                                <tr>
+                                    <td className="section-header">{key === 0 ? 'This week' : `In ${key} week${key === 1 ? '' : 's'}`}</td>
+                                </tr>
+                                {
+                                    this.props.data[key].map((elem, index) =>
+                                        <tr key={index}>
+                                            <td>{moment(elem.Date, 'DD-MMM-YY').format('MMM D')}</td>
+                                            <td className="wide">{moment(elem.Start, 'h:mm').format('h:mm a')} - {moment(elem.End, 'h:mm').format('h:mm a')}</td>
+                                            <td>{elem.Location.charAt(0) + elem.Location.substr(1).toLowerCase()}</td>
+                                            <td>
+                                                <div className="dots">
+                                                    {elem.Names.map((e, i) =>
+                                                        <div className="dot" style={{ backgroundColor: this.props.clinicians[e].color }} key={i}></div>)}
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <Icon className="save-button" style={{color: "purple"}} onClick={(e) => this.onClickSave(e, elem)}>
+                                                    bookmark_border
+                                                </Icon>
+                                            </td>
+                                        </tr>
+                                    )
+                                }
+                            </tbody>
+                          )) }
+                      </div>
+                </table>
+            </div>
+            <Modal
+                isOpen={this.state.open}
+                onClose={this.close}
+                center
+                classNames={{modal: "customModal", overlay: "customOverlay"}}>
+                <form onSubmit={this.handleSubmit}>
+                    <label>Clinician Notes:</label>
+                    <div>
+                        <textarea name="notes" value={this.state.note} onChange={this.handleChange} className="notebox" rows="4"/>
+                    </div>
+                    <div className="save-button-container">
+                        <button type="submit" value="Submit" className="save-note">Save Time</button>
+                    </div>
+                </form>
+            </Modal>
+            </div>
         )
     }
 }


### PR DESCRIPTION
Modal wasn't popping up b/c the attribute should have been
```
isOpen={this.state.open}
```
and not
```
open={this.state.open}
```
Model component has been moved out of the `<table>`.

Saving notes now works!

Additional notes:
- the saved message is broken, it shows me the same message for all notes
- modal should have a close button, the only way to exit modal is to click “save time”
- no way to save times through calendar view
- there’s nothing in the saved times schema that would indicate which user saved that entry, I believe that there was never a time where users could see only their saved times